### PR TITLE
feat: add support for Hello World events

### DIFF
--- a/src/actions/common.tsx
+++ b/src/actions/common.tsx
@@ -19,6 +19,18 @@ export async function emailAlreadyUsed(
   return registrations.length !== 0;
 }
 
+export async function teamAlreadyUsed(team: string, eventId: string) {
+  const registrations = await directus().request(
+    readItems('registrations', {
+      filter: {
+        _and: [{ team: { _eq: team } }, { event: { _eq: eventId } }],
+      },
+    })
+  );
+
+  return registrations.length !== 0;
+}
+
 export async function getRegistrations(eventId: string) {
   return await directus().request(
     readItems('registrations', { filter: { event: { _eq: eventId } } })

--- a/src/actions/common.tsx
+++ b/src/actions/common.tsx
@@ -19,18 +19,6 @@ export async function emailAlreadyUsed(
   return registrations.length !== 0;
 }
 
-export async function teamAlreadyUsed(team: string, eventId: string) {
-  const registrations = await directus().request(
-    readItems('registrations', {
-      filter: {
-        _and: [{ team: { _eq: team } }, { event: { _eq: eventId } }],
-      },
-    })
-  );
-
-  return registrations.length !== 0;
-}
-
 export async function getRegistrations(eventId: string) {
   return await directus().request(
     readItems('registrations', { filter: { event: { _eq: eventId } } })

--- a/src/actions/hello-world.tsx
+++ b/src/actions/hello-world.tsx
@@ -1,6 +1,28 @@
 'use server';
 import { directus } from '@/directus';
-import { createItems, readItem } from '@directus/sdk';
+import { createItems, readItem, readItems } from '@directus/sdk';
+
+export async function teamAlreadyUsed(team: string, eventId: string) {
+  const registrations = await directus().request(
+    readItems('registrations', {
+      filter: {
+        _and: [{ team: { _eq: team } }, { event: { _eq: eventId } }],
+      },
+    })
+  );
+
+  return registrations.length !== 0;
+}
+
+export async function getTeamMembers(team: string, eventId: string) {
+  return await directus().request(
+    readItems('registrations', {
+      filter: {
+        _and: [{ team: { _eq: team } }, { event: { _eq: eventId } }],
+      },
+    })
+  );
+}
 
 export async function sendRegistration({
   first_name,

--- a/src/actions/hello-world.tsx
+++ b/src/actions/hello-world.tsx
@@ -1,0 +1,37 @@
+'use server';
+import { directus } from '@/directus';
+import { createItems, readItem } from '@directus/sdk';
+
+export async function sendRegistration({
+  first_name,
+  last_name,
+  email,
+  section,
+  year,
+  team,
+  eventId,
+  comments,
+}) {
+  const event = await directus().request(readItem('events', eventId));
+
+  if (!event.opened) {
+    throw new Error('Not opened');
+  }
+
+  const eventRegistration = {
+    event: eventId,
+    email,
+    first_name,
+    family_name: last_name,
+    year,
+    section,
+    team,
+    comments,
+  };
+
+  const createdRegistration = await directus().request(
+    createItems('registrations', [eventRegistration])
+  );
+
+  return createdRegistration[0].id;
+}

--- a/src/app/[eventSlug]/[admin]/checkin/CheckIn.tsx
+++ b/src/app/[eventSlug]/[admin]/checkin/CheckIn.tsx
@@ -4,7 +4,11 @@ import ParticipantDisplay from '@/components/ParticipantDisplay';
 import QRScannerSelector from '@/components/QRScannerSelector';
 import { Event, Registration } from '@/types/aliases';
 import { useState } from 'react';
-import { FDCheckinDialog, ICBDCheckinDialog } from './CheckinDialog';
+import {
+  FDCheckinDialog,
+  HWCheckinDialog,
+  ICBDCheckinDialog,
+} from './CheckinDialog';
 
 export function CheckIn({
   participants: initialParticipants,
@@ -38,6 +42,15 @@ export function CheckIn({
             case 'faculty_dinner':
               return (
                 <FDCheckinDialog
+                  event={event}
+                  close={close}
+                  participant={participant}
+                  setParticipants={setParticipants}
+                />
+              );
+            case 'hello_world':
+              return (
+                <HWCheckinDialog
                   event={event}
                   close={close}
                   participant={participant}

--- a/src/app/[eventSlug]/[admin]/checkin/CheckinDialog.tsx
+++ b/src/app/[eventSlug]/[admin]/checkin/CheckinDialog.tsx
@@ -149,3 +149,44 @@ export function FDCheckinDialog({
     </>
   );
 }
+
+export function HWCheckinDialog({
+  event,
+  close,
+  participant,
+  setParticipants,
+}: { event: Event } & DialogDefaultProps) {
+  const [payment, setPayment] = useState(null);
+
+  return (
+    <>
+      <Split>
+        <b>{`${participant.first_name} ${participant.family_name}`}</b>
+        <span>{participant.team}</span>
+      </Split>
+
+      {participant.checked_in ? (
+        <Card>
+          <CheckCircleIcon className="icon" />
+          Already checked in
+        </Card>
+      ) : (
+        <>
+          <button
+            onClick={async () => {
+              const newRes = await checkInRegistration(participant.id);
+              setParticipants((value) => [
+                ...value.filter((p) => p.id != participant.id),
+                newRes,
+              ]);
+            }}
+          >
+            Check-in
+          </button>
+        </>
+      )}
+
+      <button onClick={close}>Close</button>
+    </>
+  );
+}

--- a/src/app/[eventSlug]/[admin]/checkin/CheckinDialog.tsx
+++ b/src/app/[eventSlug]/[admin]/checkin/CheckinDialog.tsx
@@ -1,12 +1,14 @@
 import { checkInRegistration, markPayment } from '@/actions/common';
+import { getTeamMembers } from '@/actions/hello-world';
 import { returnDeposit } from '@/actions/icbd';
 import Card from '@/components/Card';
 import DropdownCard from '@/components/DropdownCard';
 import CheckCircleIcon from '@/components/icons/CheckCircleIcon';
+import ErrorIcon from '@/components/icons/ErrorIcon';
 import PriceIcon from '@/components/icons/PriceIcon';
 import Split from '@/components/Split';
 import { Event, Registration } from '@/types/aliases';
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
 interface DialogDefaultProps {
   participant: Registration;
@@ -156,34 +158,80 @@ export function HWCheckinDialog({
   participant,
   setParticipants,
 }: { event: Event } & DialogDefaultProps) {
-  const [payment, setPayment] = useState(null);
+  const [teamMembers, setTeamMembers] = useState<Registration[]>([]);
 
-  return (
+  useEffect(() => {
+    getTeamMembers(participant.team, event.id.toString()).then((members) =>
+      setTeamMembers(members)
+    );
+  }, [teamMembers]);
+
+  return teamMembers.length === 0 ? (
+    <>Loading team members...</>
+  ) : (
     <>
-      <Split>
-        <b>{`${participant.first_name} ${participant.family_name}`}</b>
-        <span>{participant.team}</span>
-      </Split>
+      <b>{participant.team}</b>
 
-      {participant.checked_in ? (
+      {teamMembers.length != 3 ? (
+        <>
+          <Card>
+            <ErrorIcon className="icon" />
+            Team {participant.team} has {teamMembers.length} members rather than
+            3 !
+          </Card>
+        </>
+      ) : null}
+
+      {teamMembers.map((member) => (
+        <>
+          <Split>
+            <span className="center-text half">
+              <b>{`${member.first_name} ${member.family_name}`}</b>
+            </span>
+            {member.checked_in ? (
+              <Card key={member.id}>
+                <CheckCircleIcon className="icon" />
+                Already checked in
+              </Card>
+            ) : (
+              <button
+                onClick={async () => {
+                  const newRes = await checkInRegistration(member.id);
+                  setParticipants((value) => [
+                    ...value.filter((p) => p.id != member.id),
+                    newRes,
+                  ]);
+                }}
+                key={member.id}
+              >
+                Check-in {member.first_name} {member.family_name}
+              </button>
+            )}
+          </Split>
+        </>
+      ))}
+
+      {teamMembers.filter((member) => !member.checked_in).length === 0 ? (
         <Card>
           <CheckCircleIcon className="icon" />
-          Already checked in
+          All team members checked in
         </Card>
       ) : (
-        <>
-          <button
-            onClick={async () => {
-              const newRes = await checkInRegistration(participant.id);
-              setParticipants((value) => [
-                ...value.filter((p) => p.id != participant.id),
-                newRes,
-              ]);
-            }}
-          >
-            Check-in
-          </button>
-        </>
+        <button
+          onClick={async () => {
+            for (const member of teamMembers) {
+              if (!member.checked_in) {
+                const newRes = await checkInRegistration(member.id);
+                setParticipants((value) => [
+                  ...value.filter((p) => p.id != member.id),
+                  newRes,
+                ]);
+              }
+            }
+          }}
+        >
+          Check-in all team
+        </button>
       )}
 
       <button onClick={close}>Close</button>

--- a/src/app/[eventSlug]/[admin]/page.tsx
+++ b/src/app/[eventSlug]/[admin]/page.tsx
@@ -54,6 +54,16 @@ export default async function AdminPanel({ params }) {
         </div>
       );
 
+    case 'hello_world':
+      return (
+        <div className="form">
+          <h1>Admin panel</h1>
+          <Link href={`${params.admin}/checkin`}>
+            <Card Icon={TicketIcon}>Check-in</Card>
+          </Link>
+        </div>
+      );
+
     default:
       break;
   }

--- a/src/app/[eventSlug]/hello-world.tsx
+++ b/src/app/[eventSlug]/hello-world.tsx
@@ -1,0 +1,18 @@
+import HelloWorldForm from '@/components/forms/HelloWorldForm';
+import { Event } from '@/types/aliases';
+
+export default async function HelloWorld({ event }: { event: Event }) {
+  let date = new Date(event.from).toLocaleDateString('fr-FR', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  return (
+    <HelloWorldForm
+      eventId={event.id.toString()}
+      date={`${date}`}
+      location="BC Building"
+      deposit={`${event.price ?? 0}CHF`}
+    />
+  );
+}

--- a/src/app/[eventSlug]/page.tsx
+++ b/src/app/[eventSlug]/page.tsx
@@ -4,6 +4,7 @@ import { readItems } from '@directus/sdk';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import FacultyDinner from './faculty-dinner';
+import HelloWorld from './hello-world';
 import ICBD from './icbd';
 
 export default async function Home({ params }) {
@@ -51,6 +52,8 @@ export default async function Home({ params }) {
       return <ICBD event={event}></ICBD>;
     case 'faculty_dinner':
       return <FacultyDinner event={event}></FacultyDinner>;
+    case 'hello_world':
+      return <HelloWorld event={event}></HelloWorld>;
   }
 }
 

--- a/src/components/ParticipantDisplay.tsx
+++ b/src/components/ParticipantDisplay.tsx
@@ -18,7 +18,9 @@ export default function ParticipantDisplay({
     case 'icbd':
       return <ICBDParticipantDisplay participant={participant} />;
     case 'faculty_dinner':
-      return <FDParticipantDisplay participant={participant} />;
+      return <SimpleParticipantDisplay participant={participant} />;
+    case 'hello_world':
+      return <SimpleParticipantDisplay participant={participant} />;
     default:
       break;
   }
@@ -65,7 +67,11 @@ function ICBDParticipantDisplay({
   );
 }
 
-function FDParticipantDisplay({ participant }: { participant: Registration }) {
+function SimpleParticipantDisplay({
+  participant,
+}: {
+  participant: Registration;
+}) {
   return (
     <div className="participant-display">
       <Split>

--- a/src/components/forms/HelloWorldForm.tsx
+++ b/src/components/forms/HelloWorldForm.tsx
@@ -272,6 +272,12 @@ function Form({
   return (
     <>
       <section>
+        <p>
+          To register for Hello World, you need to have formed a team of 3.
+          <br />
+          If you do not yet have a team, you can look for one on the{' '}
+          <a href="https://t.me/+kwrmi0cIc75jNjM0">Hello World Group Finder</a>.
+        </p>
         {[1, 2, 3].map((i) => (
           <>
             <h2>Team Member {i}</h2>
@@ -328,14 +334,26 @@ function Form({
           </>
         ))}
 
+        <div className="spacer"></div>
+
         <TextInputCard
           Icon={TeamIcon}
-          placeholder="Team"
+          placeholder="Team Name"
           inputState={{
             value: s.team,
             setValue: (value) => setField('team', value),
           }}
         />
+
+        <CheckboxCard
+          checkboxState={{
+            value: s.consent,
+            setValue: (value) => setField('consent', value),
+          }}
+        >
+          All three team members consent to CLIC taking photographs of them at
+          Hello World and using them for promotional purposes.
+        </CheckboxCard>
 
         <LargeTextInputCard
           Icon={PencilIcon}
@@ -346,16 +364,6 @@ function Form({
           }}
           rows={2}
         />
-
-        <CheckboxCard
-          checkboxState={{
-            value: s.consent,
-            setValue: (value) => setField('consent', value),
-          }}
-        >
-          I consent to CLIC taking photographs of me at Hello World and using
-          them for promotional purposes.
-        </CheckboxCard>
       </section>
 
       <button

--- a/src/components/forms/HelloWorldForm.tsx
+++ b/src/components/forms/HelloWorldForm.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { emailAlreadyUsed, teamAlreadyUsed } from '@/actions/common';
-import { sendRegistration } from '@/actions/hello-world';
+import { emailAlreadyUsed } from '@/actions/common';
+import { sendRegistration, teamAlreadyUsed } from '@/actions/hello-world';
 import { ElementType, ReactNode, useReducer } from 'react';
 import Card from '../Card';
 import CheckboxCard from '../CheckboxCard';

--- a/src/components/forms/HelloWorldForm.tsx
+++ b/src/components/forms/HelloWorldForm.tsx
@@ -45,7 +45,6 @@ enum Years {
   BA6 = 'BA6',
   MA2 = 'MA2',
   MA4 = 'MA4',
-  PhD = 'PhD',
   Other = 'Other',
 }
 
@@ -54,6 +53,7 @@ enum Sections {
   CommunicationSystems = 'Communication Systems',
   DataScience = 'Data Science',
   CyberSecurity = 'Cyber Security',
+  Other = 'Other',
 }
 
 async function register({
@@ -306,7 +306,7 @@ function Form({
               eventId,
               first_name: s.firstName,
               last_name: s.lastName,
-              email: s.email,
+              email: s.email.toLowerCase(),
               section: s.section,
               year: s.year,
               team: s.team,

--- a/src/components/forms/HelloWorldForm.tsx
+++ b/src/components/forms/HelloWorldForm.tsx
@@ -272,7 +272,7 @@ function Form({
   return (
     <>
       <section>
-        <p>
+        <p className="spaced-p">
           To register for Hello World, you need to have formed a team of 3.
           <br />
           If you do not yet have a team, you can look for one on the{' '}

--- a/src/components/forms/HelloWorldForm.tsx
+++ b/src/components/forms/HelloWorldForm.tsx
@@ -129,6 +129,12 @@ async function validateValues(s: State, eventId: string) {
     }
   }
 
+  const emails = members.map((m) => m.email.toLowerCase());
+  const uniqueEmails = new Set(emails);
+  if (uniqueEmails.size !== emails.length) {
+    return 'Team members must have different emails';
+  }
+
   if (!s.team || s.team.length === 0) {
     return 'Team name is required';
   }

--- a/src/components/forms/HelloWorldForm.tsx
+++ b/src/components/forms/HelloWorldForm.tsx
@@ -1,0 +1,353 @@
+'use client';
+import { emailAlreadyUsed } from '@/actions/common';
+import { sendRegistration } from '@/actions/hello-world';
+import { ElementType, ReactNode, useReducer } from 'react';
+import Card from '../Card';
+import CheckboxCard from '../CheckboxCard';
+import DropdownCard from '../DropdownCard';
+import ErrorMessage from '../ErrorMessage';
+import InfoLine from '../InfoLine';
+import LargeTextInputCard from '../LargeTextInputCard';
+import TextInputCard from '../TextInputCard';
+import CalendarIcon from '../icons/CalendarIcon';
+import CheckCircleIcon from '../icons/CheckCircleIcon';
+import EmailIcon from '../icons/EmailIcon';
+import MapPinIcon from '../icons/MapPinIcon';
+import PencilIcon from '../icons/PencilIcon';
+import PriceIcon from '../icons/PriceIcon';
+import TeamIcon from '../icons/TeamIcon';
+import UserIcon from '../icons/UserIcon';
+
+type State = {
+  formState: FormStates;
+  firstName: string;
+  lastName: string;
+  email: string;
+  section: string;
+  year: string;
+  team: string;
+  consent: boolean;
+  errorMessage: string;
+  comments: string;
+};
+
+enum FormStates {
+  Form,
+  Loading,
+  Confirmation,
+  Error,
+}
+
+enum Years {
+  MAN = 'MAN',
+  BA2 = 'BA2',
+  BA4 = 'BA4',
+  BA6 = 'BA6',
+  MA2 = 'MA2',
+  MA4 = 'MA4',
+  PhD = 'PhD',
+  Other = 'Other',
+}
+
+enum Sections {
+  ComputerScience = 'Computer Science',
+  CommunicationSystems = 'Communication Systems',
+  DataScience = 'Data Science',
+  CyberSecurity = 'Cyber Security',
+}
+
+async function register({
+  eventId,
+  first_name,
+  last_name,
+  email,
+  section,
+  year,
+  team,
+  comments,
+}) {
+  let registrationId = await sendRegistration({
+    first_name,
+    last_name,
+    email: email.toLowerCase(),
+    section,
+    year,
+    eventId,
+    team,
+    comments,
+  });
+}
+
+async function validateValues(s: State, eventId: string) {
+  if (!s.firstName || s.firstName.length === 0) {
+    return 'First name is required';
+  }
+
+  if (!s.lastName || s.lastName.length === 0) {
+    return 'Last name is required';
+  }
+
+  if (!s.email) {
+    return 'Email is required';
+  }
+  if (await emailAlreadyUsed(s.email.toLowerCase(), eventId)) {
+    return 'Email is already used';
+  }
+
+  if (!/^[A-Za-z\-]+\.[A-Za-z\-]+@epfl\.ch$/.test(s.email)) {
+    return 'Email must be EPFL email';
+  }
+
+  if (!s.section || !Object.values(Sections).includes(s.section as Sections)) {
+    return 'Section is required';
+  }
+
+  if (!s.year || !Object.values(Years).includes(s.year as Years)) {
+    return 'Year is required';
+  }
+
+  if (!s.consent) {
+    return 'Consent is required';
+  }
+
+  return null;
+}
+
+export default function HelloWorldForm({
+  eventId,
+  date,
+  location,
+  deposit,
+}: {
+  eventId: string;
+  date: string;
+  location: string;
+  deposit: string;
+}) {
+  // Info items
+  const infoItems: [ElementType, ReactNode][] = [
+    [CalendarIcon, date],
+    [MapPinIcon, location],
+    [PriceIcon, deposit],
+  ];
+
+  // Define initial state
+  const initialState: State = {
+    formState: FormStates.Form,
+    firstName: '',
+    lastName: '',
+    email: '',
+    section: '',
+    year: '',
+    team: '',
+    consent: false,
+    errorMessage: '',
+    comments: '',
+  };
+
+  // Define reducer
+  function reducer(state, action) {
+    switch (action.type) {
+      case 'SET_FIELD':
+        return { ...state, [action.field]: action.value };
+      case 'SET_ERROR':
+        return { ...state, errorMessage: action.value };
+      default:
+        throw Error('Invalid action type');
+    }
+  }
+
+  function setField(field, value) {
+    dispatch({ type: 'SET_FIELD', field, value });
+  }
+
+  // Use reducer
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return (
+    <div className="form">
+      <h1>Hello World</h1>
+      <InfoLine infoItems={infoItems}></InfoLine>
+
+      {(() => {
+        switch (state.formState) {
+          case FormStates.Form:
+            return <Form s={state} setField={setField} eventId={eventId} />;
+          case FormStates.Loading:
+            return <Loading></Loading>;
+          case FormStates.Confirmation:
+            return <Confirmation />;
+          case FormStates.Error:
+            return <ErrorDisplay message={state.errorMessage}></ErrorDisplay>;
+          default:
+            return null;
+        }
+      })()}
+    </div>
+  );
+}
+
+function Form({
+  s,
+  setField,
+  eventId,
+}: {
+  s: State;
+  setField: (field: string, value) => void;
+  eventId: string;
+}) {
+  function changeSelection(
+    index: number,
+    newValue: boolean,
+    oldValues: boolean[]
+  ) {
+    const newValues = [...oldValues];
+    newValues[index] = newValue;
+    return newValues;
+  }
+
+  return (
+    <>
+      <section>
+        <TextInputCard
+          Icon={UserIcon}
+          placeholder="First Name"
+          inputState={{
+            value: s.firstName,
+            setValue: (value) => setField('firstName', value),
+          }}
+        />
+        <TextInputCard
+          Icon={UserIcon}
+          placeholder="Last Name"
+          inputState={{
+            value: s.lastName,
+            setValue: (value) => setField('lastName', value),
+          }}
+        />
+        <TextInputCard
+          Icon={EmailIcon}
+          placeholder="EPFL Email"
+          inputState={{
+            value: s.email,
+            setValue: (value) => setField('email', value),
+          }}
+        />
+
+        <DropdownCard
+          Icon={TeamIcon}
+          placeholder="Section"
+          options={Object.values(Sections).map((v) => ({
+            display: v,
+            value: v,
+          }))}
+          dropdownState={{
+            value: s.section,
+            setValue: (value) => setField('section', value),
+          }}
+        />
+
+        <DropdownCard
+          Icon={TeamIcon}
+          placeholder="Year"
+          options={Object.values(Years).map((v) => ({
+            display: v,
+            value: v,
+          }))}
+          dropdownState={{
+            value: s.year,
+            setValue: (value) => setField('year', value),
+          }}
+        />
+
+        <TextInputCard
+          Icon={TeamIcon}
+          placeholder="Team"
+          inputState={{
+            value: s.team,
+            setValue: (value) => setField('team', value),
+          }}
+        />
+
+        <LargeTextInputCard
+          Icon={PencilIcon}
+          placeholder="Additional Comments"
+          inputState={{
+            value: s.comments,
+            setValue: (value) => setField('comments', value),
+          }}
+          rows={2}
+        />
+
+        <CheckboxCard
+          checkboxState={{
+            value: s.consent,
+            setValue: (value) => setField('consent', value),
+          }}
+        >
+          I consent to CLIC taking photographs of me at Hello World and using
+          them for promotional purposes.
+        </CheckboxCard>
+      </section>
+
+      <button
+        onClick={async () => {
+          const error = await validateValues(s, eventId);
+
+          if (error) {
+            setField('errorMessage', error);
+            return;
+          }
+
+          setField('formState', FormStates.Loading);
+
+          try {
+            await register({
+              eventId,
+              first_name: s.firstName,
+              last_name: s.lastName,
+              email: s.email,
+              section: s.section,
+              year: s.year,
+              team: s.team,
+              comments: s.comments,
+            });
+            setField('formState', FormStates.Confirmation);
+          } catch (error) {
+            setField('errorMessage', error.message);
+            setField('formState', FormStates.Error);
+          }
+        }}
+      >
+        Confirm Registration
+      </button>
+
+      <ErrorMessage message={s.errorMessage}></ErrorMessage>
+    </>
+  );
+}
+
+function Loading({}) {
+  return <p>Loading...</p>;
+}
+
+function Confirmation() {
+  return (
+    <>
+      <Card Icon={CheckCircleIcon}>
+        <p>Your registration to Hello World is successful !</p>
+      </Card>
+      <p>Check your email for confirmation, and see you soon !</p>
+    </>
+  );
+}
+
+function ErrorDisplay({ message }: { message: string }) {
+  return (
+    <>
+      <p>Registration failed: {message}</p>
+      <p>Please refresh the page and try again</p>
+      <p>Contact clic@epfl.ch if the issue persists</p>
+    </>
+  );
+}

--- a/src/components/icons/PencilIcon.tsx
+++ b/src/components/icons/PencilIcon.tsx
@@ -1,0 +1,16 @@
+import type { SVGProps } from 'react';
+
+export default function PencilIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" {...props}>
+      <path
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M4 20h4L18.5 9.5a2.828 2.828 0 1 0-4-4L4 16zm9.5-13.5l4 4"
+      ></path>
+    </svg>
+  );
+}

--- a/src/styles/base/_base.scss
+++ b/src/styles/base/_base.scss
@@ -60,6 +60,11 @@ p {
   text-align: left;
 }
 
+a {
+  color: inherit;
+  font-weight: bold;
+}
+
 .icon {
   width: 1.4rem;
 }

--- a/src/styles/base/_colors.scss
+++ b/src/styles/base/_colors.scss
@@ -1,7 +1,7 @@
 @use 'sass:color';
 
 :root {
-  $base: #00782c;
+  $base: #7a0c9f;
 
   --text-color: #{color.scale($base, $lightness: 80%)};
   --bg-color: #{$base};

--- a/src/styles/components/_split.scss
+++ b/src/styles/components/_split.scss
@@ -9,4 +9,14 @@
       white-space: nowrap;
     }
   }
+
+  .center-text {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  .half {
+    min-width: 50%;
+  }
 }

--- a/src/styles/layout/_form.scss
+++ b/src/styles/layout/_form.scss
@@ -13,4 +13,12 @@
   @media (max-width: 40rem) {
     margin-top: 4rem;
   }
+
+  p {
+    margin-bottom: 1rem;
+  }
+
+  .spacer {
+    height: 2rem;
+  }
 }

--- a/src/styles/layout/_form.scss
+++ b/src/styles/layout/_form.scss
@@ -14,7 +14,7 @@
     margin-top: 4rem;
   }
 
-  p {
+  .spaced-p {
     margin-bottom: 1rem;
   }
 


### PR DESCRIPTION
Adds support for events of type Hello World (basic format + team input).

Note: we should discuss the format of team selection. Currently, it is simply a text input field. Do we want to add a dropdown with team names that have already been registered ? It should still be clear that people should only register to teams they know, not randomly